### PR TITLE
Updates to ldaca.py tests, folder structure, readme, new download_all test

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ ldaca.retrieve_collection(
     data_dir='data')
 ```
 
+If you don't want to delete any of the previous files/directories, select clear = False
+
 Find the sub_collections of such collection
 
 ```python
@@ -70,6 +72,8 @@ ldaca.retrieve_collection(
     collection_type='Collection',
     data_dir='atomic_data')
 ```
+
+If you don't want to delete any of the previous files/directories, select clear = False
 
 Use a file_picker function, to select only the desired files
 

--- a/test/test_atomic_data.py
+++ b/test/test_atomic_data.py
@@ -24,7 +24,7 @@ def test_store_all_csv():
         data_dir=data_dir)
 
     my_file_picker = lambda f: f if f.get('encodingFormat') == 'text/csv' else None
-    all_files = ldaca.store_data(entity_type='RepositoryObject', ldaca_files='ldaca_files', file_picker=my_file_picker)
+    all_files = ldaca.store_data(entity_type='RepositoryObject', file_picker=my_file_picker)
 
     assert len(all_files) == 34
 

--- a/test/test_atomic_download_all.py
+++ b/test/test_atomic_download_all.py
@@ -23,7 +23,7 @@ def test_store_all_data():
         collection_type='Collection',
         data_dir=data_dir)
 
-    all_files = ldaca.store_data(entity_type='RepositoryObject', ldaca_files='ldaca_files')
+    all_files = ldaca.store_data(entity_type='RepositoryObject')
 
     assert len(all_files) == 102
 

--- a/test/test_fragmented_data.py
+++ b/test/test_fragmented_data.py
@@ -35,7 +35,7 @@ def test_store_all_data():
         if len(ldaca.collection_members) > 0:
             member = ldaca.collection_members[1]
             my_file_picker = lambda f: f if f.get('encodingFormat') == 'text/plain' else None
-            all_files = ldaca.store_data(entity_type='RepositoryObject', ldaca_files='ldaca_files', file_picker=new_file_picker)
+            all_files = ldaca.store_data(entity_type='RepositoryObject', file_picker=new_file_picker)
             assert len(ldaca.text_files) == 558
         else:
             assert False


### PR DESCRIPTION
- Moved clear folder to start of retrieving a collection
- ldaca_files removed to prevent redundant sub-directories in folder structure
- Added os.path.join so forward slashes in directory aren't hard-coded
- Updates to readme on running tests
- New test added: test_atomic_download_all.py